### PR TITLE
Bump markdownlint-cli to v0.35.0

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at pellared@hotmail.com. All
+reported by contacting the project team at <pellared@hotmail.com>. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/build/mdlint.go
+++ b/build/mdlint.go
@@ -24,7 +24,7 @@ var mdlint = goyek.Define(goyek.Task{
 		if len(mdFiles) == 0 {
 			a.Skip("no .md files")
 		}
-		dockerImage := "ghcr.io/igorshubovych/markdownlint-cli:v0.33.0"
+		dockerImage := "ghcr.io/igorshubovych/markdownlint-cli:v0.35.0"
 		cmd.Exec(a, "docker run --rm -v '"+curDir+":/workdir' "+dockerImage+" "+strings.Join(mdFiles, " "))
 	},
 })


### PR DESCRIPTION
Per https://github.com/igorshubovych/markdownlint-cli/releases/tag/v0.35.0