### PR TITLE
Bump markdownlint-cli to v0.36.0

### DIFF
--- a/build/mdlint.go
+++ b/build/mdlint.go
@@ -24,7 +24,7 @@ var mdlint = goyek.Define(goyek.Task{
 		if len(mdFiles) == 0 {
 			a.Skip("no .md files")
 		}
-		dockerImage := "ghcr.io/igorshubovych/markdownlint-cli:v0.35.0"
+		dockerImage := "ghcr.io/igorshubovych/markdownlint-cli:v0.36.0"
 		cmd.Exec(a, "docker run --rm -v '"+curDir+":/workdir' "+dockerImage+" "+strings.Join(mdFiles, " "))
 	},
 })


### PR DESCRIPTION
https://github.com/igorshubovych/markdownlint-cli/releases/tag/v0.36.0