### PR TITLE
Add Len to FluentSlice, FluentMap, FluentString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/fluentassert/verify/compare/v1.0.0...HEAD)
 
+### Added
+
+- Add `Len` assertion for `string`, `[]T`, `map[K]V` types.
+
 ## [1.0.0](https://github.com/fluentassert/verify/releases/tag/v1.0.0) - 2023-04-05
 
 This release contains breaking changes.

--- a/map.go
+++ b/map.go
@@ -110,7 +110,7 @@ func (x FluentMap[K, V]) All(predicate func(K, V) bool) FailureMessage {
 	return ""
 }
 
-// None tests if all of the map's pairs do not meet the predicate criteria.
+// None tests if none of the map's pairs meets the predicate criteria.
 func (x FluentMap[K, V]) None(predicate func(K, V) bool) FailureMessage {
 	for k, v := range x.Got {
 		if predicate(k, v) {

--- a/map.go
+++ b/map.go
@@ -90,7 +90,7 @@ func (x FluentMap[K, V]) NotContainPair(k K, v V, opts ...cmp.Option) FailureMes
 	return FailureMessage(fmt.Sprintf("contains the pair\ngot: %+v\nkey: %+v\nvalue: %+v", x.Got, k, v))
 }
 
-// Any tests if any of the slice's item meets the predicate criteria.
+// Any tests if any of the map's pairs meets the predicate criteria.
 func (x FluentMap[K, V]) Any(predicate func(K, V) bool) FailureMessage {
 	for k, v := range x.Got {
 		if predicate(k, v) {
@@ -100,7 +100,7 @@ func (x FluentMap[K, V]) Any(predicate func(K, V) bool) FailureMessage {
 	return FailureMessage(fmt.Sprintf("none pair does meet the predicate criteria\ngot: %+v", x.Got))
 }
 
-// All tests if all of the slice's items meets the predicate criteria.
+// All tests if all of the map's pairs meet the predicate criteria.
 func (x FluentMap[K, V]) All(predicate func(K, V) bool) FailureMessage {
 	for k, v := range x.Got {
 		if !predicate(k, v) {
@@ -110,12 +110,21 @@ func (x FluentMap[K, V]) All(predicate func(K, V) bool) FailureMessage {
 	return ""
 }
 
-// None tests if all of the slice's item does not meet the predicate criteria.
+// None tests if all of the map's pairs do not meet the predicate criteria.
 func (x FluentMap[K, V]) None(predicate func(K, V) bool) FailureMessage {
 	for k, v := range x.Got {
 		if predicate(k, v) {
 			return FailureMessage(fmt.Sprintf("a pair meets the predicate criteria\ngot: %+v\npair: %+v", x.Got, v))
 		}
+	}
+	return ""
+}
+
+// Len tests the length of the map.
+func (x FluentMap[K, V]) Len(want int) FailureMessage {
+	gotLen := len(x.Got)
+	if gotLen != want {
+		return FailureMessage(fmt.Sprintf("has different length\ngot: %+v\nlen: %v\nwant: %v", x.Got, gotLen, want))
 	}
 	return ""
 }

--- a/map_test.go
+++ b/map_test.go
@@ -134,4 +134,15 @@ func TestMap(t *testing.T) {
 			assertFailed(t, got, "a pair meets the predicate criteria")
 		})
 	})
+
+	t.Run("Len", func(t *testing.T) {
+		t.Run("Passed", func(t *testing.T) {
+			got := verify.Map(dict).Len(len(dict))
+			assertPassed(t, got)
+		})
+		t.Run("Failed", func(t *testing.T) {
+			got := verify.Map(dict).Len(10)
+			assertFailed(t, got, "has different length")
+		})
+	})
 }

--- a/slice.go
+++ b/slice.go
@@ -103,7 +103,7 @@ func (x FluentSlice[T]) NotContain(item T, opts ...cmp.Option) FailureMessage {
 	return ""
 }
 
-// Any tests if any of the slice's item meets the predicate criteria.
+// Any tests if any of the slice's items meets the predicate criteria.
 func (x FluentSlice[T]) Any(predicate func(T) bool) FailureMessage {
 	for _, v := range x.Got {
 		if predicate(v) {
@@ -113,7 +113,7 @@ func (x FluentSlice[T]) Any(predicate func(T) bool) FailureMessage {
 	return FailureMessage(fmt.Sprintf("none item does meet the predicate criteria\ngot: %+v", x.Got))
 }
 
-// All tests if all of the slice's items meets the predicate criteria.
+// All tests if all of the slice's items meet the predicate criteria.
 func (x FluentSlice[T]) All(predicate func(T) bool) FailureMessage {
 	for _, v := range x.Got {
 		if !predicate(v) {
@@ -123,12 +123,21 @@ func (x FluentSlice[T]) All(predicate func(T) bool) FailureMessage {
 	return ""
 }
 
-// None tests if all of the slice's item does not meet the predicate criteria.
+// None tests if all of the slice's items do not meet the predicate criteria.
 func (x FluentSlice[T]) None(predicate func(T) bool) FailureMessage {
 	for _, v := range x.Got {
 		if predicate(v) {
 			return FailureMessage(fmt.Sprintf("an item meets the predicate criteria\ngot: %+v\nitem: %+v", x.Got, v))
 		}
+	}
+	return ""
+}
+
+// Len tests the length of the slice.
+func (x FluentSlice[T]) Len(want int) FailureMessage {
+	gotLen := len(x.Got)
+	if gotLen != want {
+		return FailureMessage(fmt.Sprintf("has different length\ngot: %+v\nlen: %v\nwant: %v", x.Got, gotLen, want))
 	}
 	return ""
 }

--- a/slice.go
+++ b/slice.go
@@ -123,7 +123,7 @@ func (x FluentSlice[T]) All(predicate func(T) bool) FailureMessage {
 	return ""
 }
 
-// None tests if all of the slice's items do not meet the predicate criteria.
+// None tests if none of the slice's items meets the predicate criteria.
 func (x FluentSlice[T]) None(predicate func(T) bool) FailureMessage {
 	for _, v := range x.Got {
 		if predicate(v) {

--- a/slice_test.go
+++ b/slice_test.go
@@ -126,4 +126,15 @@ func TestSlice(t *testing.T) {
 			assertFailed(t, got, "an item meets the predicate criteria")
 		})
 	})
+
+	t.Run("Len", func(t *testing.T) {
+		t.Run("Passed", func(t *testing.T) {
+			got := verify.Slice(list).Len(len(list))
+			assertPassed(t, got)
+		})
+		t.Run("Failed", func(t *testing.T) {
+			got := verify.Slice(list).Len(10)
+			assertFailed(t, got, "has different length")
+		})
+	})
 }

--- a/string.go
+++ b/string.go
@@ -116,3 +116,12 @@ func (x FluentString[T]) NotMatchRegex(regex *regexp.Regexp) FailureMessage {
 	}
 	return FailureMessage(fmt.Sprintf("the string value matches the regular expression\ngot: %q\nregex: %s", x.Got, regex.String()))
 }
+
+// Len tests the length of the string.
+func (x FluentString[T]) Len(want int) FailureMessage {
+	gotLen := len(x.Got)
+	if gotLen != want {
+		return FailureMessage(fmt.Sprintf("has different length\ngot: %+v\nlen: %v\nwant: %v", x.Got, gotLen, want))
+	}
+	return ""
+}

--- a/string_test.go
+++ b/string_test.go
@@ -140,6 +140,17 @@ func TestString(t *testing.T) {
 		})
 	})
 
+	t.Run("Len", func(t *testing.T) {
+		t.Run("Passed", func(t *testing.T) {
+			got := verify.String("abc").Len(3)
+			assertPassed(t, got)
+		})
+		t.Run("Failed", func(t *testing.T) {
+			got := verify.String("abc").Len(10)
+			assertFailed(t, got, "has different length")
+		})
+	})
+
 	t.Run("has assertions from Ordered, Obj, Any", func(t *testing.T) {
 		want := "text"
 		got := verify.String(want).FluentOrdered.FluentObj.FluentAny.Got // type embedding done properly


### PR DESCRIPTION
## Why

Fixes https://github.com/fluentassert/verify/issues/123

## What

- Add `Len` to `FluentSlice`, `FluentMap`, `FluentString`.
- Opportunistic change: Refine doc comments for `Any`, `All`, `None` assertions.

## Checklist

<!-- All items should be verified and marked as done.
     If an item doesn't apply to the introduced changes - check it as done too. -->

- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated.
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
- [x] The code changes follow [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments).
- [x] The code changes are covered by tests.

<!-- markdownlint-disable-file MD041 -->
