### PR TITLE
Deprecate the library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Deprecate the whole library. Avoid using assertion libraries.
   Use the standard library and [github.com/google/go-cmp/cmp] instead.
-  Follow the offical [Go Test Comments](https://go.dev/wiki/TestComments).
+  Follow the official [Go Test Comments](https://go.dev/wiki/TestComments).
 
 ## [1.2.0](https://github.com/fluentassert/verify/releases/tag/v1.2.0) - 2024-09-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - Deprecate the whole library. Avoid using assertion libraries.
-  Use the standard library and [github.com/google/go-cmp/cmp] instead.
-  Follow the official [Go Test Comments](https://go.dev/wiki/TestComments).
+  Use the standard library and [github.com/google/go-cmp/cmp](https://pkg.go.dev/github.com/google/go-cmp/cmp)
+  instead. Follow the official [Go Test Comments](https://go.dev/wiki/TestComments).
 
 ## [1.2.0](https://github.com/fluentassert/verify/releases/tag/v1.2.0) - 2024-09-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this library are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/fluentassert/verify/compare/v1.2.0...HEAD)
+## [1.3.0](https://github.com/fluentassert/verify/releases/tag/v1.2.0) - 2025-02-17
+
+### Deprecated
+
+- Deprecate the whole library. Avoid using assertion libraries.
+  Use the standard library and [github.com/google/go-cmp/cmp] instead.
+  Follow the offical [Go Test Comments](https://go.dev/wiki/TestComments).
 
 ## [1.2.0](https://github.com/fluentassert/verify/releases/tag/v1.2.0) - 2024-09-10
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@
 > Use this library if you still want to.
 > Consider yourself warned.
 
-> Extensible, type-safe, fluent assertion Go library.
-
 [![Go Reference](https://pkg.go.dev/badge/github.com/fluentassert/verify.svg)](https://pkg.go.dev/github.com/fluentassert/verify)
 [![Keep a Changelog](https://img.shields.io/badge/changelog-Keep%20a%20Changelog-%23E05735)](CHANGELOG.md)
 [![GitHub Release](https://img.shields.io/github/v/release/fluentassert/verify)](https://github.com/fluentassert/verify/releases)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # fluentassert
 
+> [!CAUTION]
+> [Avoid using assertion libraries](https://go.dev/wiki/TestComments#assert-libraries).
+> Instead, use [`go-cmp`](https://github.com/google/go-cmp)
+> and write custom test helpers.
+> Using the popular [`testify`](https://github.com/stretchr/testify)
+> may be also an acceptable choice,
+> especially together with [`testifylint`](https://github.com/Antonboom/testifylint)
+> to avoid common mistakes.
+> Use this library if you still want to.
+> Consider yourself warned.
+
 > Extensible, type-safe, fluent assertion Go library.
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/fluentassert/verify.svg)](https://pkg.go.dev/github.com/fluentassert/verify)
@@ -21,17 +32,6 @@ to read and write ([more](https://dave.cheney.net/2019/09/24/be-wary-of-function
 The generics (type parameters) make the usage type-safe.
 
 The library is [extensible](#extensibility) by design.
-
-> [!CAUTION]
-> [Avoid using assertion libraries](https://go.dev/wiki/TestComments#assert-libraries).
-> Instead, use [`go-cmp`](https://github.com/google/go-cmp)
-> and write custom test helpers.
-> Using the popular [`testify`](https://github.com/stretchr/testify)
-> may be also an acceptable choice,
-> especially together with [`testifylint`](https://github.com/Antonboom/testifylint)
-> to avoid common mistakes.
-> Use this library if you still want to.
-> Consider yourself warned.
 
 ### Quick start
 

--- a/doc.go
+++ b/doc.go
@@ -5,4 +5,7 @@
 //
 // At last, you may embed a Fluent* type
 // to extend it with additional assertion functions.
+//
+// Deprecated: avoid using assertion libraries.
+// Use the standard library and [github.com/google/go-cmp/cmp] instead.
 package verify

--- a/doc.go
+++ b/doc.go
@@ -8,5 +8,7 @@
 //
 // Deprecated: avoid using assertion libraries.
 // Use the standard library and [github.com/google/go-cmp/cmp] instead.
-// Reference: https://go.dev/wiki/TestComments.
+// Follow the official [Go Test Comments].
+//
+// [Go Test Comments]: https://go.dev/wiki/TestComments
 package verify

--- a/doc.go
+++ b/doc.go
@@ -8,4 +8,5 @@
 //
 // Deprecated: avoid using assertion libraries.
 // Use the standard library and [github.com/google/go-cmp/cmp] instead.
+// Reference: https://go.dev/wiki/TestComments.
 package verify

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 // Deprecated: avoid using assertion libraries.
 // Use the standard library and github.com/google/go-cmp/cmp instead.
-// Reference: https://go.dev/wiki/TestComments.
+// Follow the official Go Test Comments: https://go.dev/wiki/TestComments.
 module github.com/fluentassert/verify
 
 go 1.18

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,6 @@
+// Deprecated: avoid using assertion libraries.
+// Use the standard library and github.com/google/go-cmp/cmp instead.
+// Reference: https://go.dev/wiki/TestComments.
 module github.com/fluentassert/verify
 
 go 1.18


### PR DESCRIPTION
Deprecate the whole library.
Avoid using assertion libraries.
Use the standard library and [github.com/google/go-cmp/cmp](https://pkg.go.dev/github.com/google/go-cmp/cmp) instead.
Follow the official [Go Test Comments](https://go.dev/wiki/TestComments).